### PR TITLE
Use HTTPS for file upload

### DIFF
--- a/lib/flickr/uploader.rb
+++ b/lib/flickr/uploader.rb
@@ -67,7 +67,7 @@ class Flickr::Uploader < Flickr::Base
 
     headers = {"Content-Type" => "multipart/form-data; boundary=" + form.boundary}
 
-    rsp = Net::HTTP.start('api.flickr.com').post("/services/upload/", form.to_s, headers).body
+    rsp = Net::HTTP.start('api.flickr.com', :use_ssl => true).post("/services/upload/", form.to_s, headers).body
 
     xm = XmlMagic.new(rsp)
 


### PR DESCRIPTION
Flickr deprecated the HTTP API. Upload also needs to use HTTPS.