### PR TITLE
Add settable photo attributes for extra parameter when searching photo through photosets

### DIFF
--- a/lib/flickr/photoset.rb
+++ b/lib/flickr/photoset.rb
@@ -55,6 +55,22 @@ class Flickr::Photosets::Photoset
        :secret => photo[:secret],
        :server => photo[:server],
        :farm => photo[:farm],
-       :title => photo[:title]}
+       :title => photo[:title],
+       :is_public => photo[:ispublic],
+       :is_friend => photo[:isfriend],
+       :is_family => photo[:isfamily],
+       :license_id => photo[:license].to_i,
+       :uploaded_at => (Time.at(photo[:dateupload].to_i) rescue nil),
+       :taken_at => (Time.parse(photo[:datetaken]) rescue nil),
+       :owner_name => photo[:ownername],
+       :icon_server => photo[:icon_server],
+       :original_format => photo[:originalformat],
+       :updated_at => (Time.at(photo[:lastupdate].to_i) rescue nil),
+       :geo => photo[:geo],
+       :tags => photo[:tags],
+       :machine_tags => photo[:machine_tags],
+       :o_dims => photo[:o_dims],
+       :views => photo[:views].to_i,
+       :media => photo[:media]}
     end
 end


### PR DESCRIPTION
Hi :hand: 

I want to use `date_taken` attributes of photo even in the case of using `flickr.photosets.getPhotos`.
Because it is included in the API of response, I tried adding it to `photoset.rb`.

https://www.flickr.com/services/api/flickr.photosets.getPhotos.html

> extras (Optional)
A comma-delimited list of extra information to fetch for each returned record. Currently supported fields are: license, date_upload, date_taken, owner_name, icon_server, original_format, last_update, geo, tags, machine_tags, o_dims, views, media, path_alias, url_sq, url_t, url_s, url_m, url_o

but added code is similar to [this](https://github.com/commonthread/flickr_fu/blob/master/lib/flickr/photos.rb#L221-L244). 
I want to refactor, I do not have a good idea :cry: